### PR TITLE
build(deps): Fix peer dependencies version of pino

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "typescript": "4.8.3"
   },
   "peerDependencies": {
-    "pino": "8.5.0"
+    "pino": "^8.0.0"
   }
 }


### PR DESCRIPTION
It is ok to include all of the versions from the major version of pino (at least for v8).